### PR TITLE
chore: pin Pac-Man 0.7.3 image

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install yamllint
         run: pip install yamllint
       - name: Run yamllint
-        run: yamllint -d "{extends: relaxed, rules: {line-length: disable, document-start: disable, truthy: disable, comments: disable, indentation: disable}}" .
+        run: 'yamllint -d "{extends: relaxed, rules: {line-length: disable, document-start: disable, truthy: disable, comments: disable, indentation: disable}}" .'
 
   kubeconform:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ scripts, and a catalogue of Cilium demos.
 ## Image
 
 All manifests in this repo target `docker.io/saintdle/pacman`, pinned by
-digest (`sha256:d1c36678...`). The Cilium demos accept a `PACMAN_IMAGE`
+digest (`sha256:cb927246...`). The Cilium demos accept a `PACMAN_IMAGE`
 env var override.
 
 ## Install (base mongo-backed deployment)

--- a/cilium-demos/README.md
+++ b/cilium-demos/README.md
@@ -2,7 +2,7 @@
 
 These demos use the Pac-Man app as a small but real Kubernetes workload for showing Cilium OSS, Hubble, Gateway API, Cluster Mesh, and Tetragon.
 
-Default image: `docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198`.
+Default image: `docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05`.
 Override it in scripts with `PACMAN_IMAGE=your-registry/your-image:tag`.
 
 ## Prerequisites

--- a/cilium-demos/canary-progressive-delivery/canary.yaml
+++ b/cilium-demos/canary-progressive-delivery/canary.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           ports:
             - name: http
               containerPort: 8080
@@ -62,7 +62,7 @@ spec:
     spec:
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           ports:
             - name: http
               containerPort: 8080

--- a/cilium-demos/cluster-mesh-failover/clustermesh-demo.yaml
+++ b/cilium-demos/cluster-mesh-failover/clustermesh-demo.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           ports:
             - name: http
               containerPort: 8080

--- a/cilium-demos/fault-injection-resilience/fault-demo.yaml
+++ b/cilium-demos/fault-injection-resilience/fault-demo.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           ports:
             - name: http
               containerPort: 8080

--- a/cilium-demos/grpc-grpcroute/grpcroute.yaml
+++ b/cilium-demos/grpc-grpcroute/grpcroute.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           ports:
             - name: grpc
               containerPort: 9090

--- a/cilium-demos/load-simulation/node-user-simulator.yaml
+++ b/cilium-demos/load-simulation/node-user-simulator.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: simulator
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           imagePullPolicy: IfNotPresent
           command:
             - node

--- a/cilium-demos/microservices-east-west/workloads.yaml
+++ b/cilium-demos/microservices-east-west/workloads.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: pacman-demo
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           ports:
             - name: http
               containerPort: 8080
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           ports:
             - name: http
               containerPort: 8080
@@ -104,7 +104,7 @@ spec:
     spec:
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           ports:
             - name: http
               containerPort: 8080

--- a/cilium-demos/runtime-security-incident/incident-demo.yaml
+++ b/cilium-demos/runtime-security-incident/incident-demo.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           ports:
             - name: http
               containerPort: 8080

--- a/cilium-demos/scripts/deploy-demo.sh
+++ b/cilium-demos/scripts/deploy-demo.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DEMO="${1:?usage: deploy-demo.sh <demo-directory>}"
 NAMESPACE="${NAMESPACE:-pacman-demo}"
-PACMAN_IMAGE="${PACMAN_IMAGE:-docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198}"
+PACMAN_IMAGE="${PACMAN_IMAGE:-docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05}"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RENDER_DIR="$(mktemp -d "$ROOT/.deploy-render.XXXXXX")"
 trap 'rm -rf "$RENDER_DIR"' EXIT

--- a/cilium-demos/tetragon-enforcement/tetragon-demo.yaml
+++ b/cilium-demos/tetragon-enforcement/tetragon-demo.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           ports:
             - name: http
               containerPort: 8080

--- a/cilium-demos/topology-aware-routing/topology-demo.yaml
+++ b/cilium-demos/topology-aware-routing/topology-demo.yaml
@@ -30,7 +30,7 @@ spec:
               app.kubernetes.io/component: web
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           ports:
             - name: http
               containerPort: 8080

--- a/deployments/pacman-deployment.yaml
+++ b/deployments/pacman-deployment.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: pacman
-          image: docker.io/saintdle/pacman@sha256:d1c36678cd8cb7c4a0ea7c80f8161ec39c899da20c4328d0dc4ff21ada762198
+          image: docker.io/saintdle/pacman@sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/security/secret.yaml
+++ b/security/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: mongodb-users-secret
-type: Opaque 
+type: Opaque
 data:
   database-admin-name: Y2x5ZGU=
   database-admin-password: Y2x5ZGU=


### PR DESCRIPTION
## Summary

- Update all pinned Pac-Man image references to the published 0.7.3 digest.
- Update the abbreviated image digest in the repository README.
- Quote the yamllint command so the validation workflow parses correctly.
- Fix existing whitespace violations in the Secret manifest so the lint gate can pass.

Image digest:
`sha256:cb9272461127465676fefd4778e67faea41ef65e03c19014626287d2c542dd05`

## Validation

- No stale 0.6.0 image digest remains.
- `kubeconform` validated 13 core resources against Kubernetes 1.30.
- `kubectl kustomize .` rendered successfully.
- `actionlint` passes for `.github/workflows/lint.yml`.
