### PR TITLE
ci: fix action lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install yamllint
         run: pip install yamllint
       - name: Run yamllint
-        run: yamllint -d "{extends: relaxed, rules: {line-length: disable, document-start: disable, truthy: disable, comments: disable, indentation: disable}}" .
+        run: 'yamllint -d "{extends: relaxed, rules: {line-length: disable, document-start: disable, truthy: disable, comments: disable, indentation: disable}}" .'
 
   kubeconform:
     runs-on: ubuntu-latest

--- a/security/secret.yaml
+++ b/security/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: mongodb-users-secret
-type: Opaque 
+type: Opaque
 data:
   database-admin-name: Y2x5ZGU=
   database-admin-password: Y2x5ZGU=


### PR DESCRIPTION
## Summary

- Quote the yamllint command so `.github/workflows/lint.yml` parses as valid YAML.
- Remove trailing whitespace and add the missing final newline in `security/secret.yaml` so the lint job can complete.

## Validation

- `actionlint .github/workflows/lint.yml`
- `git diff --check`
- Ruby YAML parse of `security/secret.yaml`
